### PR TITLE
Add rsync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM composer
 
+RUN set -eux; \
+  apk add --no-cache --virtual \
+    rsync
+
 RUN composer global require deployer/deployer --dev; \
     composer global require deployer/recipes --dev
 


### PR DESCRIPTION
Allow using the Rsync recipe.

Docker hub autobuild is not enabled for this repo, and the latest build of this repo is over 2yrs old.

Because of that, I've enabled auto-build on my fork: https://github.com/rvanlaak/ci-deployer/releases https://hub.docker.com/repository/docker/rvanlaak/ci-deployer